### PR TITLE
specify encoding=utf-8

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -132,7 +132,7 @@ class MixpanelUtils(object):
         open_mode = "w+"
         if append_mode:
             open_mode = "a+"
-        with open(output_file, open_mode) as output:
+        with open(output_file, open_mode, encoding="utf-8") as output:
             if format == "json":
                 json.dump(data, output)
             elif format == "csv":
@@ -1523,7 +1523,7 @@ class MixpanelUtils(object):
             header.append(key)
 
         # Create the writer and write the header
-        with open(output_file, "w") as output:
+        with open(output_file, "w", encoding="utf-8") as output:
             writer = csv.writer(output)
 
             writer.writerow(header)
@@ -1689,7 +1689,7 @@ class MixpanelUtils(object):
         except JSONDecodeError as e:
             if "Expecting value" in str(e):
                 # Based on the error message, try to treat it as CSV
-                with open(filename, "rU") as item_file:
+                with open(filename, "rU", encoding="utf-8") as item_file:
                     reader = csv.reader(item_file)
                     header = next(reader)
                     # Determine if the data is events or profiles based on keys in the header.
@@ -1770,7 +1770,7 @@ class MixpanelUtils(object):
             MixpanelUtils.LOGGER.warning(
                 "Event missing time or distinct_id property, dumping to invalid_events.txt"
             )
-            with open("invalid_events.txt", "a+") as invalid:
+            with open("invalid_events.txt", "a+", encoding="utf-8") as invalid:
                 json.dump(event, invalid)
                 invalid.write("\n")
                 return
@@ -1876,7 +1876,7 @@ class MixpanelUtils(object):
                 items, output_file, format=format, compress=compress
             )
         elif format == "csv":
-            with open(output_file, "w") as f:
+            with open(output_file, "w", encoding="utf-8") as f:
                 f.write(items)
             if compress:
                 MixpanelUtils._gzip_file(output_file)
@@ -1995,7 +1995,7 @@ class MixpanelUtils(object):
                 "Failed to import batch, dumping to file import_backup.txt",
                 exc_info=True,
             )
-            with open("import_backup.txt", "a+") as backup:
+            with open("import_backup.txt", "a+", encoding="utf-8") as backup:
                 json.dump(batch, backup)
                 backup.write("\n")
 


### PR DESCRIPTION
In Python 3, the default encoding when opening text files is system dependent, for MacOS or *nix this will be UTF-8, but for Windows it's the 8-bit Windows-1252, which was causing errors for some Windows users.  Like...

```
...."C:\Users\peter\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.9_qbz5n2kfra8p0\LocalCache\local-packages\Python39\site-packages\mixpanel_utils\__init__.py", line 1547, in _write_items_to_csv
    writer.writerow(row)
  File "C:\Program Files\WindowsApps\PythonSoftwareFoundation.Python.3.9_3.9.1520.0_x64__qbz5n2kfra8p0\lib\encodings\cp1252.py", line 19, in encode
    return codecs.charmap_encode(input,self.errors,encoding_table)[0]
UnicodeEncodeError: 'charmap' codec can't encode character '\u014c' in position 34: character maps to <undefined>
```

This change will explicitly require the use of UTF-8 encoding for all text files.

https://mixpanel.slack.com/archives/CKGL4TYF3/p1627066714155600

https://stackoverflow.com/questions/44391671/python3-unicodeencodeerror-charmap-codec-cant-encode-characters-in-position/44400442#44400442